### PR TITLE
Add options hash / Add lower casing of key names

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,33 +1,28 @@
 /**
- * ImageMagickIdentifyReader(text[, options]) -> ImageMagickIdentifyReader
+ * ImageMagickIdentifyReader(text[, transform]) -> ImageMagickIdentifyReader
  * - text (String): Output text from the `identify` program.
- * - options (Object): Optional options hash:
- *   - camelCase (Boolean): Optional. If property names should be converted to
- *     camelCase. Defaults to `false`.
- *   - lowerCase (Boolean): Optional. If property names should be converted to
- *     lower case. Defaults to `false`.
- *   - Backwards compatibility: If `options` is not an Object and `false`(-ish),
- *     we assume `camelCase` is meant (to remain compatible).
+ * - transform (String): Optional key transformation: "camel" | "lower"
  *
  * Returns a parsed object representation of the input string.
+ *
+ * The optional `transform` argument can instruct this module to transform keys
+ * into different formats: "camel" converts keys to camelCase and "lower" to
+ * lower case. For backwards compatibility, the Boolean value `true` will be
+ * treated as "camel".
 **/
 
-function ImageMagickIdentifyReader(text, options) {
+function ImageMagickIdentifyReader(text, transform) {
   if (this instanceof ImageMagickIdentifyReader) {
     throw new Error('Invalid use - this module is to be called, not instantiated.');
   }
 
-  if (options instanceof Object) {
-    options = {
-      camelCase: options.camelCase || false,
-      lowerCase: options.lowerCase || false
-    };
-  } else {
-    // Backwards compatibility: Set camelCase if `options` is not an Object.
-    options = {
-      camelCase: !!options,
-      lowerCase: false
-    };
+  if (typeof transform === "string") {
+    if (transform !== "lower" && transform !== "camel") {
+      throw new Error('Invalid argument `transform`: must be either `camel` or `lower`.');
+    }
+  } else if (!!transform) {
+    // Backwards compatibility: Set camelCase if `transform` is true(ish) but not a String.
+    transform = "camel";
   }
 
   if (!isString(text)) {
@@ -79,14 +74,14 @@ function ImageMagickIdentifyReader(text, options) {
       var key = line.slice(0, index).trim();
       var value = line.slice(index + 1).trim() || {};
 
-      if (options.camelCase) {
+      if (transform === "camel") {
         // Replace all non-word and underscore characters with a non-sequential space.
         key = key.replace(/[\W_]/g, ' ').replace(/\s+/g, ' ').toLowerCase();
         // Replace initial char in each work with an uppercase version.
         key = key.replace(/ \w/g, function(x) { return x.trim().toUpperCase(); });
       }
 
-      if (options.lowerCase) {
+      if (transform === "lower") {
         key = key.toLowerCase();
       }
 

--- a/main.js
+++ b/main.js
@@ -4,6 +4,8 @@
  * - options (Object): Optional options hash:
  *   - camelCase (Boolean): Optional. If property names should be converted to
  *     camelCase. Defaults to `false`.
+ *   - lowerCase (Boolean): Optional. If property names should be converted to
+ *     lower case. Defaults to `false`.
  *   - Backwards compatibility: If `options` is not an Object and `false`(-ish),
  *     we assume `camelCase` is meant (to remain compatible).
  *
@@ -17,12 +19,14 @@ function ImageMagickIdentifyReader(text, options) {
 
   if (options instanceof Object) {
     options = {
-      camelCase: options.camelCase || false
+      camelCase: options.camelCase || false,
+      lowerCase: options.lowerCase || false
     };
   } else {
     // Backwards compatibility: Set camelCase if `options` is not an Object.
     options = {
-      camelCase: !!options
+      camelCase: !!options,
+      lowerCase: false
     };
   }
 
@@ -80,6 +84,10 @@ function ImageMagickIdentifyReader(text, options) {
         key = key.replace(/[\W_]/g, ' ').replace(/\s+/g, ' ').toLowerCase();
         // Replace initial char in each work with an uppercase version.
         key = key.replace(/ \w/g, function(x) { return x.trim().toUpperCase(); });
+      }
+
+      if (options.lowerCase) {
+        key = key.toLowerCase();
       }
 
       if (isString(value)) {

--- a/main.js
+++ b/main.js
@@ -1,15 +1,29 @@
 /**
- * ImageMagickIdentifyReader(text[, camelCase = false]) -> ImageMagickIdentifyReader
+ * ImageMagickIdentifyReader(text[, options]) -> ImageMagickIdentifyReader
  * - text (String): Output text from the `identify` program.
- * - camelCase (Boolean): Optional. If property names should be converted to
- *   camelCase. Defaults to `false`.
+ * - options (Object): Optional options hash:
+ *   - camelCase (Boolean): Optional. If property names should be converted to
+ *     camelCase. Defaults to `false`.
+ *   - Backwards compatibility: If `options` is not an Object and `false`(-ish),
+ *     we assume `camelCase` is meant (to remain compatible).
  *
  * Returns a parsed object representation of the input string.
 **/
 
-function ImageMagickIdentifyReader(text, camelCase) {
+function ImageMagickIdentifyReader(text, options) {
   if (this instanceof ImageMagickIdentifyReader) {
     throw new Error('Invalid use - this module is to be called, not instantiated.');
+  }
+
+  if (options instanceof Object) {
+    options = {
+      camelCase: options.camelCase || false
+    };
+  } else {
+    // Backwards compatibility: Set camelCase if `options` is not an Object.
+    options = {
+      camelCase: !!options
+    };
   }
 
   if (!isString(text)) {
@@ -61,7 +75,7 @@ function ImageMagickIdentifyReader(text, camelCase) {
       var key = line.slice(0, index).trim();
       var value = line.slice(index + 1).trim() || {};
 
-      if (camelCase) {
+      if (options.camelCase) {
         // Replace all non-word and underscore characters with a non-sequential space.
         key = key.replace(/[\W_]/g, ' ').replace(/\s+/g, ' ').toLowerCase();
         // Replace initial char in each work with an uppercase version.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Dan Dean <@dandean> (http://dandean.com)",
   "name": "imagemagick-identify-parser",
   "description": "Parses output from the `identify` program into an object.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "homepage": "https://github.com/dandean/imagemagick-identify-parser",
   "repository": {
     "type": "git",

--- a/test/test.js
+++ b/test/test.js
@@ -33,8 +33,14 @@ describe('Module', function(){
 
   it('should convert property names to camelCase when specified', function() {
     assert.ok(Object.keys(result).indexOf('Image statistics') > -1);
-    result = reader(input, true);
-    assert.ok(Object.keys(result).indexOf('imageStatistics') > -1);
+    var result2 = reader(input, true);
+    assert.ok(Object.keys(result2).indexOf('imageStatistics') > -1);
+  });
+
+  it('should convert property names to lower case when specified', function() {
+    assert.ok(Object.keys(result).indexOf('Image statistics') > -1);
+    var result2 = reader(input, {lowerCase: true});
+    assert.ok(Object.keys(result2).indexOf('image statistics') > -1);
   });
 
   it('should extract `width` and `height` properties from `geometry` property', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -33,13 +33,17 @@ describe('Module', function(){
 
   it('should convert property names to camelCase when specified', function() {
     assert.ok(Object.keys(result).indexOf('Image statistics') > -1);
+
     var result2 = reader(input, true);
     assert.ok(Object.keys(result2).indexOf('imageStatistics') > -1);
+
+    var result3 = reader(input, "camel");
+    assert.ok(Object.keys(result3).indexOf('imageStatistics') > -1);
   });
 
   it('should convert property names to lower case when specified', function() {
     assert.ok(Object.keys(result).indexOf('Image statistics') > -1);
-    var result2 = reader(input, {lowerCase: true});
+    var result2 = reader(input, "lower");
     assert.ok(Object.keys(result2).indexOf('image statistics') > -1);
   });
 


### PR DESCRIPTION
I want to integrate your parser into the NodeJS 'node-imagemagick' module (https://npmjs.org/package/imagemagick) because the parser in that module won't digest bogon input (as I receive it from graphics magick for a couple of test images) and is not very legible.

`node-imagemagick` likes to have the keys of the parsed Identify output lowercased, and the IMHO best way is to add that feature to your module.

I have added a unit test.
I have not added a test for combining lowerCase=true with camelCase=true, though it is possible to do.

<!---
@huboard:{"order":2.5}
-->
